### PR TITLE
[SP-169] Fix broken install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,6 @@ requires = [
     "nvidia-cuda-runtime-cu11",
     "nvidia-nvtx-cu11",
     "nvidia-cudnn-cu11",
+    "nvidia-cuda-cupti-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "nvidia-cuda-runtime-cu11",
     "nvidia-nvtx-cu11",
     "nvidia-cudnn-cu11",
-    "nvidia-cuda-cupti-cu11",
+    "nvidia-cuda-cupti-cu11==11.7.101",
     "nvidia-cusparse-cu11",
     "nvidia-nccl-cu11",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ requires = [
     "nvidia-nvtx-cu11",
     "nvidia-cudnn-cu11",
     "nvidia-cuda-cupti-cu11==11.7.101",
+    "nvidia-cusparse-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,6 @@ requires = [
     "nvidia-cudnn-cu11",
     "nvidia-cuda-cupti-cu11==11.7.101",
     "nvidia-cusparse-cu11",
+    "nvidia-nccl-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,6 @@ requires = [
     "nvidia-cufft-cu11",
     "nvidia-cublas-cu11",
     "nvidia-cuda-runtime-cu11",
+    "nvidia-nvtx-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
-requires = ["setuptools", "wheel", "torch", "nvidia-curand-cu11"]
+requires = [
+    "setuptools",
+    "wheel",
+    "torch",
+    "nvidia-curand-cu11",
+    "nvidia-cufft-cu11",
+    ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "torch"]
+requires = ["setuptools", "wheel", "torch", "nvidia-curand-cu11"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ requires = [
     "nvidia-cublas-cu11",
     "nvidia-cuda-runtime-cu11",
     "nvidia-nvtx-cu11",
+    "nvidia-cudnn-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,6 @@ requires = [
     "torch",
     "nvidia-curand-cu11",
     "nvidia-cufft-cu11",
+    "nvidia-cublas-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,6 @@ requires = [
     "nvidia-curand-cu11",
     "nvidia-cufft-cu11",
     "nvidia-cublas-cu11",
+    "nvidia-cuda-runtime-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@ requires = [
     "nvidia-cuda-runtime-cu11",
     "nvidia-nvtx-cu11",
     "nvidia-cudnn-cu11",
-    "nvidia-cuda-cupti-cu11",
+    "nvidia-cuda-cupti-cu11==11.7.101",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "nvidia-cuda-runtime-cu11",
     "nvidia-nvtx-cu11",
     "nvidia-cudnn-cu11",
-    "nvidia-cuda-cupti-cu11==11.7.101",
+    "nvidia-cuda-cupti-cu11",
     "nvidia-cusparse-cu11",
     "nvidia-nccl-cu11",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools",
     "wheel",
     "torch",
-    "nvidia-curand-cu11",
-    "nvidia-cufft-cu11",
+    "nvidia",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "torch",
-    "nvidia",
+    "nvidia-curand-cu11",
+    "nvidia-cufft-cu11",
     ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ setup(
             "nvidia-cufft-cu11",
             "nvidia-nvtx-cu11",
             "nvidia-cuda-cupti-cu11==11.7.101",
+            "nvidia-cusparse-cu11",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,7 @@ setup(
         "cuda": [
             "nvidia-curand-cu11",
             "nvidia-cufft-cu11",
+            "nvidia-nvtx-cu11",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,7 @@ setup(
             "nvidia-curand-cu11",
             "nvidia-cufft-cu11",
             "nvidia-nvtx-cu11",
+            "nvidia-cuda-cupti-cu11",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ setup(
             "nvidia-curand-cu11",
             "nvidia-cufft-cu11",
             "nvidia-nvtx-cu11",
-            "nvidia-cuda-cupti-cu11",
+            "nvidia-cuda-cupti-cu11==11.7.101",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,7 @@ setup(
             "nvidia-nvtx-cu11",
             "nvidia-cuda-cupti-cu11==11.7.101",
             "nvidia-cusparse-cu11",
+            "nvidia-nccl-cu11",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,16 @@ setup(
             "flake8-comprehensions",
             "black==22.3.0",
         ],
+        # temporary torch specific dependencies. 
+        # Install them by `pip install 'detectron2[cuda]'` 
+        # This goes completely against the philosophy mentioned above, but was 
+        # required to fix a bug where torch no longer included required cuda files.
+        # NOTE: this fix is intended to only be temporary and should hopefully be
+        # removed in the future.
+        "cuda": [
+            "nvidia-curand-cu11",
+            "nvidia-cufft-cu11",
+        ],
     },
     ext_modules=get_extensions(),
     cmdclass={"build_ext": torch.utils.cpp_extension.BuildExtension},

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,10 @@ setup(
         "cuda": [
             "nvidia-curand-cu11",
             "nvidia-cufft-cu11",
+            "nvidia-cublas-cu11",
+            "nvidia-cuda-runtime-cu11==11.7.99",
             "nvidia-nvtx-cu11",
+            "nvidia-cudnn-cu11==8.5.0.96",
             "nvidia-cuda-cupti-cu11==11.7.101",
             "nvidia-cusparse-cu11",
             "nvidia-nccl-cu11",


### PR DESCRIPTION
Detectron2 requires a working installation of Pytorch and makes a bunch of underlying assumptions about cuda support.
We recently ran into issues where not all the assumed cuda support was available via the installed torch package. 
This seems to be an issue on the side of Pytorch where the first uploaded wheel sets the dependecies for the package, see [issue 100974](https://github.com/pytorch/pytorch/issues/100974), and [issue 7902](https://github.com/python-poetry/poetry/issues/7902#issuecomment-1583078794).

- Added specific cuda support packages required at build-time to the build-system requirements
- Added specific cuda support packages as an installable extras option, this can be used if torch doesn't provide all the required cuda support packages.


